### PR TITLE
feat: GitHub Action for auto-assigning issue/PR authors

### DIFF
--- a/.github/workflows/assign-author.yml
+++ b/.github/workflows/assign-author.yml
@@ -1,0 +1,15 @@
+name: Assign Author
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+jobs:
+  assign-author:
+    if: ${{ ! contains(fromJson('[\"renovate[bot]\", \"dependabot[bot]\"]'), github.actor) }}
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/assign-author@v1


### PR DESCRIPTION
## Summary
Issues/PRsの作成者を自動でアサインするGitHub Actionを追加

### 📋 機能
- **Issues**: 作成・再オープン時に作成者を自動アサイン
- **Pull Requests**: 作成・再オープン・レビュー準備完了時に作成者を自動アサイン
- **Bot除外**: renovate[bot]とdependabot[bot]は除外

### 🛠 技術仕様
- **アクション**: technote-space/assign-author@v1
- **権限**: issues: write, pull-requests: write
- **トリガー**: opened, reopened, ready_for_review

### ✅ メリット
- Issue/PR作成時の手動アサインが不要
- プロジェクト管理の効率化
- タスクの責任所在の明確化

## Test plan
- [x] ワークフローファイルの構文確認
- [ ] 新しいIssue作成でのテスト (マージ後)
- [ ] 新しいPR作成でのテスト (マージ後)

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated workflow to assign authors to newly opened or reopened issues and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->