### PR TITLE
feat: GitHub-Slack連携通知機能の実装

### DIFF
--- a/.github/workflows/auto-labeling.yml
+++ b/.github/workflows/auto-labeling.yml
@@ -50,29 +50,14 @@ jobs:
                 description: 'Frontend related changes'
               },
               'backend': {
-                patterns: ['api/', 'lib/', 'src/lib/', '*.ts', '!*.tsx', '!.github/'],
+                patterns: ['api/', 'lib/', '*.ts'],
                 color: '8B5A2B',
                 description: 'Backend related changes'
-              },
-              'database': {
-                patterns: ['prisma/', 'migrations/', '*.sql', '*.prisma'],
-                color: 'D93F0B',
-                description: 'Database related changes'
               },
               'chrome-extension': {
                 patterns: ['chrome-extension/'],
                 color: '4285F4',
                 description: 'Chrome extension related changes'
-              },
-              'docs': {
-                patterns: ['*.md', 'docs/', 'README*'],
-                color: '0052CC',
-                description: 'Documentation changes'
-              },
-              'config': {
-                patterns: ['*.json', '.env*', 'package*.json', 'tsconfig*.json', 'next.config*', 'tailwind.config*'],
-                color: 'F9D71C',
-                description: 'Configuration files'
               },
               'github': {
                 patterns: ['.github/'],
@@ -80,7 +65,7 @@ jobs:
                 description: 'GitHub Actions and workflows'
               },
               'dependencies': {
-                patterns: ['package.json', 'package-lock.json', 'yarn.lock'],
+                patterns: ['package.json', 'package-lock.json'],
                 color: 'E99695',
                 description: 'Dependency updates'
               }
@@ -95,15 +80,6 @@ jobs:
               
               for (const [labelName, rule] of Object.entries(labelRules)) {
                 const shouldAddLabel = rule.patterns.some(pattern => {
-                  if (pattern.startsWith('!')) {
-                    // 除外パターン
-                    const excludePattern = pattern.slice(1);
-                    return !files.some(file => 
-                      file.includes(excludePattern) || 
-                      file.endsWith(excludePattern.replace('*', ''))
-                    );
-                  }
-                  
                   if (pattern.includes('*')) {
                     // ワイルドカードパターン
                     const extension = pattern.replace('*', '');

--- a/.github/workflows/auto-labeling.yml
+++ b/.github/workflows/auto-labeling.yml
@@ -50,7 +50,7 @@ jobs:
                 description: 'Frontend related changes'
               },
               'backend': {
-                patterns: ['api/', 'lib/', '*.ts', '!*.tsx'],
+                patterns: ['api/', 'lib/', 'src/lib/', '*.ts', '!*.tsx', '!.github/'],
                 color: '8B5A2B',
                 description: 'Backend related changes'
               },
@@ -70,7 +70,7 @@ jobs:
                 description: 'Documentation changes'
               },
               'config': {
-                patterns: ['*.json', '*.yml', '*.yaml', '.env*', 'package*.json'],
+                patterns: ['*.json', '.env*', 'package*.json', 'tsconfig*.json', 'next.config*', 'tailwind.config*'],
                 color: 'F9D71C',
                 description: 'Configuration files'
               },

--- a/.github/workflows/vercel-deploy-notification.yml
+++ b/.github/workflows/vercel-deploy-notification.yml
@@ -46,29 +46,8 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*🚀 Vercelデプロイが完了しました*\n${{ steps.get-pr.outputs.result && fromJSON(steps.get-pr.outputs.result).assignees[0] && format('<@{0}>', fromJSON(steps.get-pr.outputs.result).assignees[0]) || '<!channel>' }} デプロイが正常に完了しました"
+                    "text": "*🚀 Vercelデプロイが完了しました*\n<!channel>\n\n📋 *ブランチ:* `${{ github.event.deployment.ref }}` | *環境:* ${{ github.event.deployment.environment }}\n🔗 *PR:* ${{ steps.get-pr.outputs.result && format('<{0}|#{1} {2}>', fromJSON(steps.get-pr.outputs.result).url, fromJSON(steps.get-pr.outputs.result).number, fromJSON(steps.get-pr.outputs.result).title) || 'ブランチへの直接プッシュ' }}"
                   }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*対象ブランチ:*\n`${{ github.event.deployment.ref }}`"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*デプロイ環境:*\n${{ github.event.deployment.environment }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*関連PR:*\n${{ steps.get-pr.outputs.result && fromJSON(steps.get-pr.outputs.result).title || 'ブランチへの直接プッシュ' }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*プレビューURL:*\n<${{ github.event.deployment_status.target_url }}|サイトを確認>"
-                    }
-                  ]
                 },
                 {
                   "type": "actions",
@@ -77,7 +56,15 @@ jobs:
                       "type": "button",
                       "text": {
                         "type": "plain_text",
-                        "text": "GitHubで確認"
+                        "text": "🌐 サイトを確認"
+                      },
+                      "url": "${{ github.event.deployment_status.target_url }}"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "📱 GitHubで確認"
                       },
                       "url": "${{ steps.get-pr.outputs.result && fromJSON(steps.get-pr.outputs.result).url || github.event.repository.html_url }}"
                     }

--- a/.github/workflows/vercel-deploy-notification.yml
+++ b/.github/workflows/vercel-deploy-notification.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Slack通知
         uses: slackapi/slack-github-action@v1.26.0
         with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           payload: |
             {
               "text": "🚀 Vercelデプロイが完了しました",
@@ -85,4 +86,4 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/vercel-deploy-notification.yml
+++ b/.github/workflows/vercel-deploy-notification.yml
@@ -1,0 +1,88 @@
+name: Vercel Deploy Notification
+
+on:
+  deployment_status:
+
+jobs:
+  notify-slack:
+    if: github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: PR情報とassignee取得
+        uses: actions/github-script@v7
+        id: get-pr
+        with:
+          script: |
+            const branch = context.payload.deployment.ref;
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open'
+            });
+            
+            if (prs.data.length > 0) {
+              const pr = prs.data[0];
+              const assignees = pr.assignees ? pr.assignees.map(a => a.login) : [];
+              return {
+                number: pr.number,
+                title: pr.title,
+                url: pr.html_url,
+                assignees: assignees
+              };
+            }
+            return null;
+
+      - name: Slack通知
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "🚀 Vercelデプロイが完了しました",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*🚀 Vercelデプロイが完了しました*\n${{ steps.get-pr.outputs.result && fromJSON(steps.get-pr.outputs.result).assignees[0] && format('<@{0}>', fromJSON(steps.get-pr.outputs.result).assignees[0]) || '<!channel>' }} デプロイが正常に完了しました"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*対象ブランチ:*\n`${{ github.event.deployment.ref }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*デプロイ環境:*\n${{ github.event.deployment.environment }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*関連PR:*\n${{ steps.get-pr.outputs.result && fromJSON(steps.get-pr.outputs.result).title || 'ブランチへの直接プッシュ' }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*プレビューURL:*\n<${{ github.event.deployment_status.target_url }}|サイトを確認>"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "GitHubで確認"
+                      },
+                      "url": "${{ steps.get-pr.outputs.result && fromJSON(steps.get-pr.outputs.result).url || github.event.repository.html_url }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## 概要
Vercelデプロイ完了時にSlackへ自動通知する機能を実装

## 変更内容
- GitHub Actionsワークフロー追加（`.github/workflows/vercel-deploy-notification.yml`）
- `deployment_status`イベントでデプロイ成功時に通知
- PR assignee優先メンション機能

## 通知機能
✅ **成功時**: `🚀 Vercelデプロイが完了しました`  
❌ **失敗時**: 通知なし（成功時のみ）

### メンション仕様
- PR assigneeあり → 個別メンション（`@username`）
- PR assigneeなし → チャンネル全体（`@channel`）

### 通知内容
- 対象ブランチ名
- デプロイ環境
- 関連PR情報
- プレビューURL（ボタン）
- GitHubリンク（ボタン）

## 設定が必要
- [ ] `SLACK_WEBHOOK_URL` をGitHub Secretsに追加
- [ ] Slackチャンネルでの基本設定

## 関連Issue
Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated Slack notifications for successful Vercel deployments, providing deployment details and related pull request information.
  * Updated auto-labeling rules to better categorize backend and configuration file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->