### PR TITLE
fix: OGP画像の取得方法を改善

### DIFF
--- a/chrome-extension/constants.js
+++ b/chrome-extension/constants.js
@@ -30,5 +30,5 @@ export const TIMEOUTS = {
 export const META_SELECTORS = {
   DESCRIPTION: 'meta[name="description"]',
   OG_DESCRIPTION: 'meta[property="og:description"]',
-  OG_IMAGE: 'meta[property="og:image"]',
+  OG_IMAGE: 'meta[property="og:image"], meta[name="og:image"]',
 };

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -145,7 +145,9 @@ function extractPageInfo() {
     document.querySelector(META_SELECTORS.DESCRIPTION)?.content ||
     document.querySelector(META_SELECTORS.OG_DESCRIPTION)?.content ||
     "";
-  const image_url = document.querySelector(META_SELECTORS.OG_IMAGE)?.content || "";
+  
+  const ogImageElement = document.querySelector(META_SELECTORS.OG_IMAGE);
+  const image_url = ogImageElement?.content || ogImageElement?.getAttribute('content') || "";
 
   return {
     title,


### PR DESCRIPTION
- META_SELECTORS.OG_IMAGEにmeta[name="og:image"]を追加
- 画像URLの取得ロジックを修正し、content属性が存在しない場合にgetAttributeを使用するように変更