### PR TITLE
feat: PR reviewer通知のSlackワークフローを追加

### DIFF
--- a/.github/workflows/pr-assigned-notify.yml
+++ b/.github/workflows/pr-assigned-notify.yml
@@ -15,14 +15,10 @@ jobs:
           status: custom
           custom_payload: |
             {
-              "text": "📝 Review requested: ${{ github.event.pull_request.title }}",
+              "text": "📝 Review requested: ${{ github.event.pull_request.title }}\n<@${{ fromJson(secrets.SLACK_USER_MAP)[github.event.requested_reviewer.login] }}>${{ github.event.pull_request.assignee != null && format(' <@{0}>', fromJson(secrets.SLACK_USER_MAP)[github.event.pull_request.assignee.login]) || '' }}",
               "attachments": [{
                 "color": "warning",
                 "fields": [{
-                  "title": "Reviewer",
-                  "value": "<@${{ fromJson(secrets.SLACK_USER_MAP)[github.event.requested_reviewer.login] }}>",
-                  "short": true
-                }${{ github.event.pull_request.assignee != null && format(', {{"title": "Assignee", "value": "<@{0}>", "short": true}}', fromJson(secrets.SLACK_USER_MAP)[github.event.pull_request.assignee.login]) || '' }}, {
                   "title": "PR",
                   "value": "<${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }}>",
                   "short": true

--- a/.github/workflows/pr-assigned-notify.yml
+++ b/.github/workflows/pr-assigned-notify.yml
@@ -1,0 +1,33 @@
+name: PR Review Request Notification
+on:
+  pull_request:
+    types: [review_requested]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    # reviewerが存在する場合のみ実行
+    if: github.event.requested_reviewer != null
+    steps:
+      - name: Send Slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: |
+            {
+              "text": "📝 Review requested: ${{ github.event.pull_request.title }}",
+              "attachments": [{
+                "color": "warning",
+                "fields": [{
+                  "title": "Reviewer",
+                  "value": "<@${{ fromJson(secrets.SLACK_USER_MAP)[github.event.requested_reviewer.login] }}>",
+                  "short": true
+                }${{ github.event.pull_request.assignee != null && format(', {{"title": "Assignee", "value": "<@{0}>", "short": true}}', fromJson(secrets.SLACK_USER_MAP)[github.event.pull_request.assignee.login]) || '' }}, {
+                  "title": "PR",
+                  "value": "<${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }}>",
+                  "short": true
+                }]
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- PR reviewerが追加された時にSlackに通知するワークフローを追加
- reviewerとassignee（いれば）両方にメンションが飛ぶ
- 後からreviewerが追加されても通知される

## 必要な設定
GitHub Secretsに以下を追加してください：
- `SLACK_WEBHOOK_URL`: Slack webhook URL
- `SLACK_USER_MAP`: `{"mizok-o": "U12345678", "mu-u-u": "U87654321"}`

## Test plan
- [ ] reviewer追加時にSlack通知が送信されることを確認
- [ ] reviewerとassigneeの両方にメンションが飛ぶことを確認
- [ ] 複数回reviewer追加時に都度通知されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)